### PR TITLE
Fix null folder names and rename header variables

### DIFF
--- a/ParLibrary/Converter/ParArchiveReader.cs
+++ b/ParLibrary/Converter/ParArchiveReader.cs
@@ -74,9 +74,9 @@ namespace ParLibrary.Converter
                 throw new FormatException("PARC: Bad magic Id.");
             }
 
-            result.Root.Tags["Unknown#1"] = reader.ReadInt32();
-            result.Root.Tags["Unknown#2"] = reader.ReadInt32();
-            result.Root.Tags["Unknown#3"] = reader.ReadInt32();
+            result.Root.Tags["Endianness"] = reader.ReadInt32();
+            result.Root.Tags["Version"] = reader.ReadInt32();
+            result.Root.Tags["DataSize"] = reader.ReadInt32();
 
             int totalFolderCount = reader.ReadInt32();
             int folderInfoOffset = reader.ReadInt32();
@@ -87,6 +87,10 @@ namespace ParLibrary.Converter
             for (int i = 0; i < totalFolderCount; i++)
             {
                 folderNames[i] = reader.ReadString(0x40).TrimEnd('\0');
+                if (folderNames[i].Length < 1)
+                {
+                    folderNames[i] = ".";
+                }
             }
 
             var fileNames = new string[totalFileCount];

--- a/ParLibrary/Converter/ParArchiveWriter.cs
+++ b/ParLibrary/Converter/ParArchiveWriter.cs
@@ -100,27 +100,27 @@ namespace ParLibrary.Converter
             dataPosition = Align(dataPosition, 2048);
 
             writer.Write("PARC", 4, false);
-            if (source.Root.Tags.ContainsKey("Unknown#1"))
+            if (source.Root.Tags.ContainsKey("Endianness"))
             {
-                writer.Write((int)source.Root.Tags["Unknown#1"]);
+                writer.Write((int)source.Root.Tags["Endianness"]);
             }
             else
             {
                 writer.Write(0x02010000);
             }
 
-            if (source.Root.Tags.ContainsKey("Unknown#2"))
+            if (source.Root.Tags.ContainsKey("Version"))
             {
-                writer.Write((int)source.Root.Tags["Unknown#2"]);
+                writer.Write((int)source.Root.Tags["Version"]);
             }
             else
             {
                 writer.Write(0x00020001);
             }
 
-            if (source.Root.Tags.ContainsKey("Unknown#3"))
+            if (source.Root.Tags.ContainsKey("DataSize"))
             {
-                writer.Write((int)source.Root.Tags["Unknown#3"]);
+                writer.Write((int)source.Root.Tags["DataSize"]);
             }
             else
             {


### PR DESCRIPTION
Version 0x010001 (only used in Kenzan) has some archives with null folder names.

Header Unknowns were renamed, but no par files seem to use little endian, and DataSize is only used in version 0x010001