### PR TITLE
 Add the option to filter extracted and listed files in a GMD by regex

### DIFF
--- a/ParTool/Options/Extract.cs
+++ b/ParTool/Options/Extract.cs
@@ -31,7 +31,7 @@ namespace ParTool.Options
         public bool Recursive { get; set; }
 
         /// <summary>
-        /// Gets or sets a value used as a Regex filter for which real-files to extract.
+        /// Gets or sets a value used as a Regex filter for which files to extract.
         /// </summary>
         [Option("filter", Default = null, HelpText = "Only extract files that match this RegEx (directories will always be extracted)")]
         public string FilterRegex { get; set; }

--- a/ParTool/Options/Extract.cs
+++ b/ParTool/Options/Extract.cs
@@ -1,5 +1,5 @@
 ﻿// -------------------------------------------------------
-// © Kaplas. Licensed under MIT. See LICENSE for details.
+// © Kaplas, Samuel W. Stark (TheTurboTurnip). Licensed under MIT. See LICENSE for details.
 // -------------------------------------------------------
 namespace ParTool.Options
 {
@@ -29,5 +29,11 @@ namespace ParTool.Options
         /// </summary>
         [Option('r', "recursive", Default = false, HelpText = "Extract nested PAR archives.")]
         public bool Recursive { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value used as a Regex filter for which real-files to extract.
+        /// </summary>
+        [Option("filter", Default = null, HelpText = "Only extract files that match this RegEx (directories will always be extracted)")]
+        public string FilterRegex { get; set; }
     }
 }

--- a/ParTool/Options/List.cs
+++ b/ParTool/Options/List.cs
@@ -23,5 +23,11 @@ namespace ParTool.Options
         /// </summary>
         [Option('r', "recursive", Default = false, HelpText = "List nested PAR archives.")]
         public bool Recursive { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value used as a Regex filter for which real-files to extract.
+        /// </summary>
+        [Option("filter", Default = null, HelpText = "Only extract files that match this RegEx (directories will always be extracted)")]
+        public string FilterRegex { get; set; }
     }
 }

--- a/ParTool/Options/List.cs
+++ b/ParTool/Options/List.cs
@@ -1,5 +1,5 @@
 ﻿// -------------------------------------------------------
-// © Kaplas. Licensed under MIT. See LICENSE for details.
+// © Kaplas, Samuel W. Stark (TheTurboTurnip). Licensed under MIT. See LICENSE for details.
 // -------------------------------------------------------
 namespace ParTool.Options
 {
@@ -25,9 +25,9 @@ namespace ParTool.Options
         public bool Recursive { get; set; }
 
         /// <summary>
-        /// Gets or sets a value used as a Regex filter for which real-files to extract.
+        /// Gets or sets a value used as a Regex filter for which files to list.
         /// </summary>
-        [Option("filter", Default = null, HelpText = "Only extract files that match this RegEx (directories will always be extracted)")]
+        [Option("filter", Default = null, HelpText = "Only list files that match this RegEx")]
         public string FilterRegex { get; set; }
     }
 }

--- a/ParTool/Program.Extract.cs
+++ b/ParTool/Program.Extract.cs
@@ -1,5 +1,5 @@
 // -------------------------------------------------------
-// © Kaplas. Licensed under MIT. See LICENSE for details.
+// © Kaplas, Samuel W. Stark (TheTurboTurnip). Licensed under MIT. See LICENSE for details.
 // -------------------------------------------------------
 namespace ParTool
 {
@@ -72,7 +72,7 @@ namespace ParTool
                 // If the filterRegex exists, skip files that don't match it
                 if (filterRegex != null && !filterRegex.IsMatch(node.Path))
                 {
-                    Console.WriteLine($"Skipping {node.Path} because it doesn't match the filter");
+                    Console.WriteLine($"Skipping {node.Path}");
                     continue;
                 }
 

--- a/ParTool/Program.Extract.cs
+++ b/ParTool/Program.Extract.cs
@@ -5,6 +5,7 @@ namespace ParTool
 {
     using System;
     using System.IO;
+    using System.Text.RegularExpressions;
     using ParLibrary;
     using ParLibrary.Converter;
     using Yarhl.FileSystem;
@@ -39,6 +40,9 @@ namespace ParTool
 
             Directory.CreateDirectory(opts.OutputDirectory);
 
+            // If a FilterRegex was specified (i.e. is not null) then make a new Regex using it. Otherwise, set filterRegex to null.
+            var filterRegex = (opts.FilterRegex == null) ? null : new Regex(opts.FilterRegex);
+
             var parameters = new ParArchiveReaderParameters
             {
                 Recursive = opts.Recursive,
@@ -47,10 +51,10 @@ namespace ParTool
             using Node par = NodeFactory.FromFile(opts.ParArchivePath, Yarhl.IO.FileOpenMode.Read);
             par.TransformWith<ParArchiveReader, ParArchiveReaderParameters>(parameters);
 
-            Extract(par, opts.OutputDirectory);
+            Extract(par, filterRegex, opts.OutputDirectory);
         }
 
-        private static void Extract(Node parNode, string outputFolder)
+        private static void Extract(Node parNode, Regex filterRegex, string outputFolder)
         {
             foreach (Node node in Navigator.IterateNodes(parNode))
             {
@@ -62,6 +66,13 @@ namespace ParTool
                 if (file == null)
                 {
                     Directory.CreateDirectory(outputPath);
+                    continue;
+                }
+
+                // If the filterRegex exists, skip files that don't match it
+                if (filterRegex != null && !filterRegex.IsMatch(node.Path))
+                {
+                    Console.WriteLine($"Skipping {node.Path} because it doesn't match the filter");
                     continue;
                 }
 

--- a/ParTool/Program.List.cs
+++ b/ParTool/Program.List.cs
@@ -1,5 +1,5 @@
 // -------------------------------------------------------
-// © Kaplas. Licensed under MIT. See LICENSE for details.
+// © Kaplas, Samuel W. Stark (TheTurboTurnip). Licensed under MIT. See LICENSE for details.
 // -------------------------------------------------------
 namespace ParTool
 {

--- a/ParTool/Program.List.cs
+++ b/ParTool/Program.List.cs
@@ -5,6 +5,7 @@ namespace ParTool
 {
     using System;
     using System.IO;
+    using System.Text.RegularExpressions;
     using ParLibrary;
     using ParLibrary.Converter;
     using Yarhl.FileSystem;
@@ -24,6 +25,9 @@ namespace ParTool
                 return;
             }
 
+            // If a FilterRegex was specified (i.e. is not null) then make a new Regex using it. Otherwise, set filterRegex to null.
+            var filterRegex = (opts.FilterRegex == null) ? null : new Regex(opts.FilterRegex);
+
             var parameters = new ParArchiveReaderParameters
             {
                 Recursive = opts.Recursive,
@@ -37,6 +41,12 @@ namespace ParTool
                 var file = node.GetFormatAs<ParFile>();
                 if (file != null)
                 {
+                    // If the filterRegex exists, skip files that don't match it
+                    if (filterRegex != null && !filterRegex.IsMatch(node.Path))
+                    {
+                        continue;
+                    }
+
                     var compression = file.IsCompressed ? "*" : string.Empty;
                     Console.WriteLine($"{node.Path}{compression}\t{file.DecompressedSize} bytes\t{file.FileDate:G}");
                 }

--- a/README.md
+++ b/README.md
@@ -10,19 +10,27 @@ It supports ***SLLZ*** compression (Including ***SLLZ V2*** used in Yakuza Kiwam
 ## Usage
 - **List mode**
 
-  `ParTool.exe list <archive.par> [-r]`
+  `ParTool.exe list <archive.par> [-r] [--filter "<regex filter>"]`
   
   Reads a PAR archive and shows it contents.
   
   `-r` parameter enables *recursive* mode and shows the contents of nested PAR archives.
+
+  `--filter` parameter filters output lines using a user-provided regular expression.
   
 - **Extraction mode**
 
-  `ParTool.exe extract <archive.par> <output_directory> [-r]`
+  `ParTool.exe extract <archive.par> <output_directory> [-r] [--filter "<regex filter>"]`
   
   Extracts the PAR archive contents to the specified directory.
   
   `-r` parameter enables *recursive* mode and extracts the contents of nested PAR archives.
+
+  `--filter` parameter filters extracted files using a user-provided regular expression.
+  Files that do not match the filter will not be extracted.
+  Directories are always extracted.
+  When combined with `-r`, files matching the filter inside nested PAR archives will be extracted.
+
   
 - **Creation mode**
 

--- a/README.md
+++ b/README.md
@@ -10,17 +10,23 @@ It supports ***SLLZ*** compression (Including ***SLLZ V2*** used in Yakuza Kiwam
 ## Usage
 - **List mode**
 
-  `ParTool.exe list <archive.par> [-r] [--filter "<regex filter>"]`
+  `ParTool.exe list <archive.par> [-r] [--filter '<regex filter>']`
   
   Reads a PAR archive and shows it contents.
   
   `-r` parameter enables *recursive* mode and shows the contents of nested PAR archives.
 
   `--filter` parameter filters output lines using a user-provided regular expression.
+
+  For example, `ParTool.exe list mesh.par -r --filter '\.gmd$'` will only list GMD files (files that end with the characters '.gmd').
+  See [https://regexr.com/7q33s] for an explanation of this regular expression, and [the .NET Regular Expression Quick Reference](https://learn.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-language-quick-reference) for a complete guide to the syntax.
   
+  If using Powershell, use single quotes `'` to surround the expression to avoid variable expansion [(see the Powershell docs)](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules?view=powershell-7.4#single-quoted-strings).
+  If using Command Prompt, use double quotes.
+
 - **Extraction mode**
 
-  `ParTool.exe extract <archive.par> <output_directory> [-r] [--filter "<regex filter>"]`
+  `ParTool.exe extract <archive.par> <output_directory> [-r] [--filter '<regex filter>']`
   
   Extracts the PAR archive contents to the specified directory.
   
@@ -31,7 +37,12 @@ It supports ***SLLZ*** compression (Including ***SLLZ V2*** used in Yakuza Kiwam
   Directories are always extracted.
   When combined with `-r`, files matching the filter inside nested PAR archives will be extracted.
 
-  
+  For example, `ParTool.exe extract mesh.par -r --filter '\.gmd$'` will only extract GMD files (files that end with the characters '.gmd').
+  See [https://regexr.com/7q33s] for an explanation of this regular expression, and [the .NET Regular Expression Quick Reference](https://learn.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-language-quick-reference) for a complete guide to the syntax.
+
+  If using Powershell, use single quotes `'` to surround the expression to avoid variable expansion [(see the Powershell docs)](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules?view=powershell-7.4#single-quoted-strings).
+  If using Command Prompt, use double quotes.
+
 - **Creation mode**
 
   `ParTool.exe create <input_directory> <archive.par> [-c compression_mode] [--alternative-mode]`


### PR DESCRIPTION
I'm currently working on bulk-gathering statistics and information on GMD files, and to avoid filling my hard drive with useless files I added this feature so I could extract *only* GMD files from various pars.

Includes documentation in the README.

I haven't bumped the version.